### PR TITLE
Implement checksums to verify file integrity

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ aversion = "0.2"
 serde = { version = "1.0", features = ["derive"] }
 byteorder = "1.4"
 thiserror = "1.0"
+crc32c = "0.6.0"
 
 [dev-dependencies]
 tempfile = "3.2"

--- a/README.md
+++ b/README.md
@@ -21,4 +21,6 @@ A chapter's offset, length, and id number are all kept in a *Table of Contents*
 stored at the end of the file. The TOC will be read when a Book is opened,
 but no chapters will be read until requested.
 
+A crc32c checksum is used to ensure file integrity.
+
 License: Apache-2.0

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,8 @@
 //! A chapter's offset, length, and id number are all kept in a *Table of Contents*
 //! stored at the end of the file. The TOC will be read when a Book is opened,
 //! but no chapters will be read until requested.
+//!
+//! A crc32c checksum is used to ensure file integrity.
 
 #![warn(missing_docs)]
 #![forbid(unsafe_code)]
@@ -29,11 +31,13 @@ use thiserror::Error;
 
 mod book;
 #[doc(inline)]
-pub use book::{Book, BookWriter, ChapterId, ChapterWriter};
+pub use book::{Book, BookWriter, ChapterId, ChapterWriter, ChecksumVerification};
 
 mod read;
 #[doc(inline)]
 pub use read::BoundedReader;
+
+mod writer;
 
 /// Book error type
 #[derive(Debug, Error)]
@@ -50,6 +54,9 @@ pub enum BookError {
     /// The requested chapter was not found.
     #[error("Chapter not found")]
     NoChapter,
+    /// The computed checksum did not match the stored checksum
+    #[error("Checksum verification error")]
+    Checksum,
 }
 
 impl From<CborDataError> for BookError {

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -1,0 +1,49 @@
+use std::io::{self, Write};
+
+use crc32c::crc32c_append;
+
+/// Helper struct for checksumming and counting the bytes written to an
+/// [`io::Write`].
+#[derive(Debug)]
+pub struct ChecksummedWriter<W> {
+    writer: W,
+    current_offset: usize,
+    checksum: u32,
+}
+
+impl<I: Write> ChecksummedWriter<I> {
+    pub fn new(writer: I) -> Self {
+        Self {
+            writer,
+            current_offset: 0,
+            checksum: 0,
+        }
+    }
+
+    /// Returns the number of bytes written so far.
+    pub fn get_offset(&self) -> usize {
+        self.current_offset
+    }
+
+    /// Returns the crc32c checksum of all bytes written so far.
+    pub fn get_checksum(&self) -> u32 {
+        self.checksum
+    }
+
+    pub fn close(self) -> I {
+        self.writer
+    }
+}
+
+impl<I: Write> Write for ChecksummedWriter<I> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let bytes_written = self.writer.write(buf)?;
+        self.current_offset += bytes_written;
+        self.checksum = crc32c_append(self.checksum, &buf[..bytes_written]);
+        Ok(bytes_written)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.writer.flush()
+    }
+}


### PR DESCRIPTION
A 32 bit checksum is added immediately after the header. It is equal to
the crc32c checksum of the entire file, with the checksum bytes zeroed.

Open questions: 
- Should we require a checksum when writing?
- Should we require verifying the checksum when reading?
- Should we just put the checksum at the very end of the file?